### PR TITLE
initial add for rpm building

### DIFF
--- a/ion-connect.spec
+++ b/ion-connect.spec
@@ -1,0 +1,22 @@
+Name:    ion-connect
+Version: 0.7.3
+Release: 1%{?dist}
+Summary: CLI tool for accessing the Ion Channel API
+
+License: ASL2.0
+Source0: ion-connect
+BuildArch: x86_64
+
+%description
+The official CLI tool for interacting with the Ion Channel API. This tool
+allows Ion Channel users to access the full set of services provided by 
+Ion Channel
+
+%install
+mkdir -p %{buildroot}/%{_bindir}
+install -p -m 755 %{SOURCE0} %{buildroot}/%{_bindir}
+
+%files
+%{_bindir}/ion-connect
+
+%changelog


### PR DESCRIPTION
This does not successfully build the rpm just yet.  I just wanted to get this into the repo to start the process of building the rpm.

Currently when running:

```bash
fedpkg --dist f23 local
````

The rpm builds. After installing the built rpm the following is shown when running ion-connect:

```bash
ion-connect
2016/11/12 14:58:34 could not locate box "../config"
```