### PR TITLE
Ignore OSX 386 as build target for releasing.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,10 @@ builds:
     - windows
     - linux
 
+  ignore:
+    - goos: darwin
+      goarch: 386
+
 archives:
   -
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
Darwin/386 is no longer supported by Go. Don't build for it. 😸 