### PR TITLE
Allow aliases from SPDX files for better product resolution.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/franela/goblin v0.0.0-20201006155558-6240afcb2eb7 // indirect
 	github.com/fsnotify/fsnotify v1.4.8-0.20190312181446-1485a34d5d57 // indirect
 	github.com/hashicorp/hcl v1.0.1-0.20190611123218-cf7d376da96d // indirect
-	github.com/ion-channel/ionic v0.20.1-0.20210223223604-cd7abc41239c
+	github.com/ion-channel/ionic v0.20.1-0.20210316181735-5dd49c4a0647
 	github.com/onsi/gomega v1.10.4 // indirect
 	github.com/pelletier/go-toml v1.4.1-0.20190910035959-26fd12ff5458 // indirect
 	github.com/spdx/tools-golang v0.0.0-20201122192914-a16d50ee1552

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,10 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ion-channel/ionic v0.20.1-0.20210223223604-cd7abc41239c h1:jxgGRv7R5LIhEQT8guungMLA36X7RAaTJ3JQVsYwtmA=
 github.com/ion-channel/ionic v0.20.1-0.20210223223604-cd7abc41239c/go.mod h1:i7QxJfEfC18RBNeKAX60+Sm1+cwcdGmh7GrixsnZwLI=
+github.com/ion-channel/ionic v0.20.1-0.20210315224401-0a5a3cd66a86 h1:K0q48IfuBkBqLex3fQVimbT6+QH/WtfMmEOOUQQPXcE=
+github.com/ion-channel/ionic v0.20.1-0.20210315224401-0a5a3cd66a86/go.mod h1:i7QxJfEfC18RBNeKAX60+Sm1+cwcdGmh7GrixsnZwLI=
+github.com/ion-channel/ionic v0.20.1-0.20210316181735-5dd49c4a0647 h1:jA1pG0fZP5pj3e0M6+zJEg2Ke6tgGBrZ7YsX/OGGT/Q=
+github.com/ion-channel/ionic v0.20.1-0.20210316181735-5dd49c4a0647/go.mod h1:i7QxJfEfC18RBNeKAX60+Sm1+cwcdGmh7GrixsnZwLI=
 github.com/ion-channel/tools-golang v0.0.0-20210303235310-1dcd58345f76 h1:Oy3VjMIqZy9K8YpiNGlWsCGD+yFD4Hq3jzPmU52E3Bo=
 github.com/ion-channel/tools-golang v0.0.0-20210303235310-1dcd58345f76/go.mod h1:RO4Y3IFROJnz+43JKm1YOrbtgQNljW4gAPpA/sY2eqo=
 github.com/ion-channel/tools-golang v0.0.0-20210315174624-e403235229f9 h1:8lp7kXgy9NtDgA0TXmRDWyW/GykGNmPWfjBA357CNXc=

--- a/vendor/github.com/ion-channel/ionic/products/products.go
+++ b/vendor/github.com/ion-channel/ionic/products/products.go
@@ -35,6 +35,7 @@ type Product struct {
 	Sources            []Source      `json:"source" xml:"source"`
 	Confidence         float64       `json:"confidence" xml:"confidence"`
 	VulnerabilityCount int           `json:"vulnerability_count" xml:"vulnerability_count"`
+	Mttr               *int64        `json:"mttr_seconds" xml:"mttr_seconds"`
 	Vulnerabilities    []interface{} `json:"vulnerabilities" xml:"vulnerabilities"`
 }
 

--- a/vendor/github.com/ion-channel/ionic/scans/results.go
+++ b/vendor/github.com/ion-channel/ionic/scans/results.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ion-channel/ionic/dependencies"
+	"github.com/ion-channel/ionic/secrets"
 	"github.com/ion-channel/ionic/vulnerabilities"
 )
 
@@ -25,6 +26,7 @@ type UntranslatedResults struct {
 	Virus                   *VirusResults                   `json:"clamav,omitempty"`
 	VirusDetails            *ClamavDetails                  `json:"clam_av_details,omitempty"`
 	Vulnerability           *VulnerabilityResults           `json:"vulnerabilities,omitempty"`
+	Secret                  *SecretResults                  `json:"secrets,omitempty"`
 }
 
 // Translate moves information from the particular sub-struct, IE
@@ -70,6 +72,10 @@ func (u *UntranslatedResults) Translate() *TranslatedResults {
 	if u.License != nil {
 		tr.Type = "license"
 		tr.Data = *u.License
+	}
+	if u.Secret != nil {
+		tr.Type = "secrets"
+		tr.Data = *u.Secret
 	}
 	if u.Virus != nil {
 		tr.Type = "virus"
@@ -173,6 +179,14 @@ func (r *TranslatedResults) UnmarshalJSON(b []byte) error {
 		}
 
 		r.Data = l
+	case "secrets":
+		var b SecretResults
+		err := json.Unmarshal(tr.RawData, &b)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshall secrets results: %v", err)
+		}
+
+		r.Data = b
 	case "virus", "clamav":
 		var v VirusResults
 		err := json.Unmarshal(tr.RawData, &v)
@@ -412,6 +426,36 @@ type ClamavDetails struct {
 	ClamavDbVersion string `json:"clamav_db_version" xml:"clamav_db_version"`
 }
 
+// Secret derived struct for results specific data
+type Secret struct {
+	secrets.Secret
+	File string `json:"file" xml:"file"`
+}
+
+// SecretResults contains secrets finding data
+type SecretResults struct {
+	Secrets []Secret `json:"secrets" xml:"secrets"`
+}
+
+// MarshalJSON meets the marshaller interface to custom wrangle an ecosystem
+// result into the json shape
+func (e SecretResults) MarshalJSON() ([]byte, error) {
+	return json.Marshal(e.Secrets)
+}
+
+// UnmarshalJSON meets the unmarshaller interface to custom wrangle the
+// ecosystem scan into an ecosystem result
+func (e *SecretResults) UnmarshalJSON(b []byte) error {
+	var s []Secret
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal secrets result: %v", err.Error())
+	}
+
+	e.Secrets = s
+	return nil
+}
+
 // VirusResults represents the data collected from a virus scan.  It includes
 // information of the viruses seen and the virus scanner used.
 type VirusResults struct {
@@ -432,7 +476,8 @@ type VirusResults struct {
 type VulnerabilityResults struct {
 	Vulnerabilities []VulnerabilityResultsProduct `json:"vulnerabilities" xml:"vulnerabilities"`
 	Meta            struct {
-		VulnerabilityCount int `json:"vulnerability_count" xml:"vulnerability_count"`
+		VulnerabilityCount int    `json:"vulnerability_count" xml:"vulnerability_count"`
+		ResolvedTo         string `json:"resolved_to" xml:"resolved_to"`
 	} `json:"meta" xml:"meta"`
 }
 

--- a/vendor/github.com/ion-channel/ionic/secrets.go
+++ b/vendor/github.com/ion-channel/ionic/secrets.go
@@ -1,0 +1,25 @@
+package ionic
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ion-channel/ionic/secrets"
+)
+
+//GetSecrets takes a text input and returns any matching secrets
+func (ic *IonClient) GetSecrets(text string, token string) ([]secrets.Secret, error) {
+	b, err := ic.Post(secrets.SecretsGetSecrets, token, nil, *bytes.NewBuffer([]byte(text)), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secrets: %v", err.Error())
+	}
+
+	var s []secrets.Secret
+	err = json.Unmarshal(b, &s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response from get secrets: %v", err.Error())
+	}
+
+	return s, nil
+}

--- a/vendor/github.com/ion-channel/ionic/secrets/secrets.go
+++ b/vendor/github.com/ion-channel/ionic/secrets/secrets.go
@@ -1,0 +1,42 @@
+package secrets
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+const (
+	// SecretsGetSecrets is a string representation of the current endpoint for getting secrets
+	SecretsGetSecrets = "v1/metadata/getSecrets"
+)
+
+// Secret is a struct containing matching data for a secret found in text
+type Secret struct {
+	// Rule - the defined rule that was matched
+	Rule string `json:"rule"`
+	// Match - the subtext that was matched
+	Match string `json:"match"`
+	// Confidence - a float value from 0.0 to 1.0 of our trust in the result
+	Confidence float32 `json:"confidence"`
+}
+
+// UnmarshalJSON custom unmarshal to mask secrets
+func (s *Secret) UnmarshalJSON(data []byte) error {
+	var v map[string]interface{}
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		return err
+	}
+
+	// t, ok := v.(Secret)
+	// if !ok {
+	// 	return fmt.Errorf("Data was not in the form of a secret")
+	// }
+	s.Rule = v["rule"].(string)
+	s.Match = v["match"].(string)
+	s.Confidence = float32(v["confidence"].(float64))
+
+	half := len(s.Match) / 2
+	s.Match = s.Match[:half] + strings.Repeat("*", half)
+	return nil
+}

--- a/vendor/github.com/ion-channel/ionic/spdx/spdx.go
+++ b/vendor/github.com/ion-channel/ionic/spdx/spdx.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/ion-channel/ionic/aliases"
 	"github.com/ion-channel/ionic/projects"
 	"github.com/spdx/tools-golang/spdx"
 	"github.com/spdx/tools-golang/spdxlib"
@@ -164,6 +165,31 @@ func ProjectPackageFromSPDX2_2(doc *spdx.Document2_2, packageName string) ([]pro
 			Monitor:     monitor,
 		}
 
+		pVersion := ""
+		if pkg.PackageVersion != "" {
+			pVersion = pkg.PackageVersion
+		}
+
+		pOrg := ""
+		if pkg.PackageSupplierOrganization != "" {
+			pOrg = pkg.PackageSupplierOrganization
+		}
+
+		pName := ""
+		if pkg.PackageName != "" {
+			pName = pkg.PackageName
+		}
+
+		// check if any of pVersion, pOrg, pName are not empty string
+		if len(pVersion) > 0 || len(pOrg) > 0 || len(pName) > 0 {
+			alias := aliases.Alias{
+				Name:    pName,
+				Org:     pOrg,
+				Version: pVersion,
+			}
+			proj.Aliases = []aliases.Alias{alias}
+		}
+
 		projs = append(projs, proj)
 
 	}
@@ -236,6 +262,31 @@ func ProjectPackageFromSPDX2_1(doc *spdx.Document2_1, packageName string) ([]pro
 			RulesetID:   &rulesetID,
 			Active:      active,
 			Monitor:     monitor,
+		}
+
+		pVersion := ""
+		if pkg.PackageVersion != "" {
+			pVersion = pkg.PackageVersion
+		}
+
+		pOrg := ""
+		if pkg.PackageSupplierOrganization != "" {
+			pOrg = pkg.PackageSupplierOrganization
+		}
+
+		pName := ""
+		if pkg.PackageName != "" {
+			pName = pkg.PackageName
+		}
+
+		// check if any of pVersion, pOrg, pName are not empty string
+		if len(pVersion) > 0 || len(pOrg) > 0 || len(pName) > 0 {
+			alias := aliases.Alias{
+				Name:    pName,
+				Org:     pOrg,
+				Version: pVersion,
+			}
+			proj.Aliases = []aliases.Alias{alias}
 		}
 
 		projs = append(projs, proj)

--- a/vendor/github.com/ion-channel/ionic/vulnerabilities/vulnerabilities.go
+++ b/vendor/github.com/ion-channel/ionic/vulnerabilities/vulnerabilities.go
@@ -47,15 +47,17 @@ type Vulnerability struct {
 	PublishedAt                 time.Time          `json:"published_at" xml:"published_at"`
 	CreatedAt                   time.Time          `json:"created_at" xml:"created_at"`
 	UpdatedAt                   time.Time          `json:"updated_at" xml:"updated_at"`
+	Mttr                        *int64             `json:"mttr_seconds" xml:"mttr_seconds"`
 }
 
 // VulnerabilityInput struct for adding a vulnerability
 type VulnerabilityInput struct {
 	Vulnerability
-	Dependencies []string   `json:"dependencies"`
-	Source       []string   `json:"source"`
-	UpdatedAt    *time.Time `json:"updated_at,omitempty"`
-	CreatedAt    *time.Time `json:"created_at,omitempty"`
+	Dependencies   []string   `json:"dependencies"`
+	Source         []string   `json:"source"`
+	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
+	CreatedAt      *time.Time `json:"created_at,omitempty"`
+	TriggerRefresh bool       `json:"trigger_refresh,omitempty"`
 }
 
 // Source represents information about where the vulnerability data came from

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,7 +19,7 @@ github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/ion-channel/ionic v0.20.1-0.20210223223604-cd7abc41239c
+# github.com/ion-channel/ionic v0.20.1-0.20210316181735-5dd49c4a0647
 ## explicit
 github.com/ion-channel/ionic
 github.com/ion-channel/ionic/aliases
@@ -39,6 +39,7 @@ github.com/ion-channel/ionic/rules
 github.com/ion-channel/ionic/rulesets
 github.com/ion-channel/ionic/scanner
 github.com/ion-channel/ionic/scans
+github.com/ion-channel/ionic/secrets
 github.com/ion-channel/ionic/spdx
 github.com/ion-channel/ionic/tags
 github.com/ion-channel/ionic/teams


### PR DESCRIPTION
From an example SPDX file with fields like:

```
PackageName: Windows XP Embedded Service Pack 2
SPDXID: SPDXRef-Windows-XP-Embedded-Service-Pack-2
PackageComment: <text>PURL is pkg:supplier/Microsoft/Windows XP Embedded Service Pack 2@SP2</text>
PackageVersion: SP2
PackageSupplier: Organization: Microsoft
Relationship: SPDXRef-doot CONTAINS SPDXRef-Windows-XP-Embedded-Service-Pack-2
PackageDownloadLocation: NOASSERTION
FilesAnalyzed: false
PackageLicenseConcluded: NOASSERTION
PackageLicenseDeclared: NOASSERTION
PackageCopyrightText: NOASSERTION
```

<img width="1119" alt="Screen Shot 2021-03-15 at 3 51 56 PM" src="https://user-images.githubusercontent.com/4998189/111231402-6e81d580-85a6-11eb-8e35-c2e95ed15821.png">
